### PR TITLE
Removing leftover artifacts after apply command

### DIFF
--- a/lib/terroir/app.py
+++ b/lib/terroir/app.py
@@ -82,7 +82,7 @@ class App(object):
                 if os.path.exists('.terraform.lock.hcl'):
                     os.unlink('.terraform.lock.hcl')
                 if os.path.exists('.terraform') and os.path.isdir('.terraform'):
-                    os.unlink('.terraform')
+                    shutil.rmtree('.terraform')
 
         return exitstatus
 

--- a/lib/terroir/app.py
+++ b/lib/terroir/app.py
@@ -78,6 +78,11 @@ class App(object):
                 if os.path.exists(tfbak_file):
                     shutil.copyfile(tfbak_file, tf_file)
                     os.unlink(tfbak_file)
+            if sys.argv[1] == "apply":
+                if os.path.exists('.terraform.lock.hcl'):
+                    os.unlink('.terraform.lock.hcl')
+                if os.path.exists('.terraform') and os.path.isdir('.terraform'):
+                    os.unlink('.terraform')
 
         return exitstatus
 


### PR DESCRIPTION
Removes leftover '.terraform' folder and '.terraform.lock.hcl' file after apply.