### PR TITLE
Implemented Infracost through the '--' argument. (Do Not Merge Yet)

### DIFF
--- a/lib/terroir/app.py
+++ b/lib/terroir/app.py
@@ -70,7 +70,11 @@ class App(object):
                 with open(tf_file, "wt") as tf_fp:
                     tf_fp.write(rendered)
 
-            exitstatus, _ = self.run_terraform(sys.argv[1:])
+            if sys.argv[1] == "--":
+                # Have to pass command within ""
+                exitstatus, _ = self.run_command(sys.argv[2])
+            else:
+                exitstatus, _ = self.run_terraform(sys.argv[1:])
 
         finally:
             for tf_file in tf_files:
@@ -99,6 +103,11 @@ class App(object):
 
             shutil.copyfile(tfbak_file, tf_file)
             os.unlink(tfbak_file)
+
+    def run_command(self, args, echo_output=True):
+        # Allows users to interact with the infracost tool, by passing any command
+        # they'd like within "" after the initial --
+        os.system(args)
 
     def run_terraform(self, args, retries_remaining=2, echo_output=True):
 


### PR DESCRIPTION
Infracost specific commands like `infracost breakdown --path .` must be passed with double quotes (`"infracost breakdown --path ."`).

Note tested this in development mode using `python3 -m pip install -e .`, would appreciate more testing when available as I'm not quite a python guru.

Example output below: 
<img width="1064" alt="Screen Shot 2022-12-23 at 11 37 14 AM" src="https://user-images.githubusercontent.com/115580549/209386281-702a2b06-5a60-4c5c-a2f8-a7fc88a30e46.png">

Did run into the following error, I assume it's a side effect of how I'm running this in dev mode.
<img width="486" alt="Screen Shot 2022-12-23 at 1 33 27 PM" src="https://user-images.githubusercontent.com/115580549/209392384-f1717a44-d8e9-4091-b650-d51d821fa82f.png">

To properly test this command out, please follow the docs linked below:
[Installation](https://www.infracost.io/docs/)
[Authentication using the terminal](https://www.infracost.io/docs/infracost_cloud/authentication/)*


* Please contact me for the api_key required to run Infracost. 

Note: If approved, functional, and it is decided to add this to our CI/CD process, I would create a `setup_infracost.sh` script that would implement this in our pipelines.